### PR TITLE
Adding library.json for platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-    "name": "Adafruit Motor Shield v2",
+    "name": "Adafruit-Motor-Shield-v2",
     "keywords": "adafruit, motor",
     "description": "Adafruit Industries: Adafruit Motor shield V2 firmware",
     "repository":

--- a/library.json
+++ b/library.json
@@ -1,0 +1,12 @@
+{
+    "name": "Adafruit Motor Shield v2",
+    "keywords": "adafruit, motor",
+    "description": "Adafruit Industries: Adafruit Motor shield V2 firmware",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/adafruit/Adafruit_Motor_Shield_V2_Library.git"
+    },
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}


### PR DESCRIPTION
This change adds a single file, library.json, to allow users of the Platformio IDE to import the library via the Platform.io library manager.
