### PR TITLE
Adds missing method calls to constant step example and adds direction…

### DIFF
--- a/examples/Accel_ConstantSpeed/Accel_ConstantSpeed.ino
+++ b/examples/Accel_ConstantSpeed/Accel_ConstantSpeed.ino
@@ -3,49 +3,95 @@
 //
 // Shows how to run AccelStepper in the simplest,
 // fixed speed mode with no accelerations
-// Requires the Adafruit_Motorshield v2 library 
+// Requires the Adafruit_Motorshield v2 library
 //   https://github.com/adafruit/Adafruit_Motor_Shield_V2_Library
-// And AccelStepper with AFMotor support 
+// And AccelStepper with AFMotor support
 //   https://github.com/adafruit/AccelStepper
 
 // This tutorial is for Adafruit Motorshield v2 only!
 // Will not work with v1 shields
 
-#include <Wire.h>
 #include <AccelStepper.h>
 #include <Adafruit_MotorShield.h>
+#include <Wire.h>
+
+bool verboseDebugging = false;
+
+// * Pulling these values out to variables so we can flip the values in the loop
+int targetDistance = 200; // * The target distance we want to move to
+int targetSpeed = 400;    // * The speed that we want to move at
 
 // Create the motor shield object with the default I2C address
-Adafruit_MotorShield AFMS = Adafruit_MotorShield(); 
+Adafruit_MotorShield AFMS = Adafruit_MotorShield();
 // Or, create it with a different I2C address (say for stacking)
-// Adafruit_MotorShield AFMS = Adafruit_MotorShield(0x61); 
+// Adafruit_MotorShield AFMS = Adafruit_MotorShield(0x61);
 
 // Connect a stepper motor with 200 steps per revolution (1.8 degree)
 // to motor port #2 (M3 and M4)
 Adafruit_StepperMotor *myStepper1 = AFMS.getStepper(200, 2);
 
 // you can change these to DOUBLE or INTERLEAVE or MICROSTEP!
-void forwardstep1() {  
+void forwardstep1()
+{
   myStepper1->onestep(FORWARD, SINGLE);
 }
-void backwardstep1() {  
+void backwardstep1()
+{
   myStepper1->onestep(BACKWARD, SINGLE);
 }
 
 AccelStepper Astepper1(forwardstep1, backwardstep1); // use functions to step
 
 void setup()
-{  
-   Serial.begin(9600);           // set up Serial library at 9600 bps
-   Serial.println("Stepper test!");
-  
-  AFMS.begin();  // create with the default frequency 1.6KHz
+{
+  Serial.begin(9600); // set up Serial library at 9600 bps
+  while (verboseDebugging && !Serial.available())
+  {
+    ;
+  }
+  Serial.println("Stepper test!");
+
+  AFMS.begin(); // create with the default frequency 1.6KHz
   //AFMS.begin(1000);  // OR with a different frequency, say 1KHz
 
-  Astepper1.setSpeed(50);	
+  // ! Note that you need to set the max speed, otherwise the stepper motor will
+  //  ! only step once per interval regardless of what `setSpeed` value you give
+  Astepper1.setMaxSpeed(1000);
+
+  Astepper1.moveTo(targetDistance);
+  Astepper1.setSpeed(targetSpeed);
 }
 
 void loop()
-{  
-   Astepper1.runSpeed();
+{
+  if (verboseDebugging)
+  {
+    Serial.print("Target Distance: ");
+    Serial.print(Astepper1.targetPosition());
+    Serial.print(" | Distance to go: ");
+    Serial.println(Astepper1.distanceToGo());
+  }
+
+  if (Astepper1.distanceToGo() == 0)
+  {
+    Serial.println("CHANGE DIRECTIONS!");
+
+    Astepper1.stop();
+    Astepper1.setSpeed(0);
+
+    Astepper1.moveTo(-Astepper1.currentPosition());
+
+    targetSpeed = targetSpeed * -1; // * flipping the sign of the target speed
+    Astepper1.setSpeed(targetSpeed);
+
+    if (verboseDebugging)
+    {
+      Serial.print("New target position: ");
+      Serial.println(Astepper1.targetPosition());
+      Serial.print("New target Speed: ");
+      Serial.println(Astepper1.speed());
+    }
+  }
+
+  Astepper1.runSpeed();
 }


### PR DESCRIPTION
# Overview 

Hi! I'm sending over this pull request to try to help other devs/makers who want to use constant speed from the AccelStepper library with the V2 motor shield in the future. 

I want to use the motor shield and the AccelStepper library for a project so I looked through the examples here to wrap my brain around how to use the library. The acceleration examples worked, but the constant speed example did not; the speed could not be changed and the stepper motor would only slowly step counter clockwise. After doing a code dive I realized that there was a call missing that kept the example from working, specifically a call to set `setMaxSpeed`. If you don't set the max speed the `setSpeed` is constrained to `1` (line 302 of the `AccelStepper.cpp` file). 

Past that I added code to the sketch to mimic the `Accel_MultiStepper.ino` by spinning the stepper back and forth which I think is a helpful example to learn from. Hopefully it's not too much. 

# Change scope 

This commit updates the Constant Speed example for the motor shield. None of the actual library code has changed. 

# Limitations
None that I know of outside of this file's existing limitation of only working on the V2 motor shield. 

---

Thank you for the motor shield and the library, it's making my job a lot easier. I hope this minor contribution helps. :bows: