### PR TITLE
Add setSpeedFine() for 12 bit resolution

### DIFF
--- a/Adafruit_MotorShield.cpp
+++ b/Adafruit_MotorShield.cpp
@@ -248,6 +248,16 @@ void Adafruit_DCMotor::setSpeed(uint8_t speed) {
 
 /**************************************************************************/
 /*!
+    @brief  Control the DC Motor speed/throttle with 12 bit resolution.
+    @param  speed The 12-bit PWM value, 0 (full off) to 4095 (full on)
+*/
+/**************************************************************************/
+void Adafruit_DCMotor::setSpeedFine(uint16_t speed) {
+  MC->setPWM(PWMpin, speed > 4095 ? 4095 : speed);
+}
+
+/**************************************************************************/
+/*!
     @brief  Set DC motor to full on.
 */
 /**************************************************************************/

--- a/Adafruit_MotorShield.h
+++ b/Adafruit_MotorShield.h
@@ -52,6 +52,7 @@ public:
   friend class Adafruit_MotorShield; ///< Let MotorShield create DCMotors
   void run(uint8_t);
   void setSpeed(uint8_t);
+  void setSpeedFine(uint16_t speed);
   void fullOn();
   void fullOff();
 


### PR DESCRIPTION
For #33. Adds new method `setSpeedFine` to allow setting speed with 12 bit resolution.

Tested with Metro M0 Express and Motor Shield V2.

```cpp
#include <Adafruit_MotorShield.h>

Adafruit_MotorShield AFMS = Adafruit_MotorShield();
Adafruit_DCMotor *myMotor = AFMS.getMotor(4);

void setup() {
  Serial.begin(9600);
  while (!Serial);
  Serial.println("Adafruit Motorshield v2 - DC Motor test!");

  if (!AFMS.begin()) {
    Serial.println("Could not find Motor Shield. Check wiring.");
    while (1);
  }
  Serial.println("Motor Shield found.");
}

void loop() {
  Serial.println("Forward!");
  myMotor->run(FORWARD);
  for (uint16_t speed=0; speed<4096; speed++) {
    myMotor->setSpeedFine(speed);
    delay(2); 
  }
  for (uint16_t speed=4095; speed!=0; speed--) {
    myMotor->setSpeedFine(speed);
    delay(2); 
  }
  
  Serial.println("Backwards!"); 
  myMotor->run(BACKWARD);
  for (uint16_t speed=0; speed<4096; speed++) {
    myMotor->setSpeedFine(speed);
    delay(2); 
  }
  for (uint16_t speed=4095; speed!=0; speed--) {
    myMotor->setSpeedFine(speed);
    delay(2); 
  }
}
```
![Screenshot from 2021-09-21 16-42-47](https://user-images.githubusercontent.com/8755041/134261767-815bf44f-34ca-4e54-b142-b88d6afb370d.png)


