### PR TITLE
Implemented Brake Mode in Run Function

### DIFF
--- a/Adafruit_MotorShield.cpp
+++ b/Adafruit_MotorShield.cpp
@@ -221,7 +221,12 @@ Adafruit_DCMotor::Adafruit_DCMotor(void) {
 /**************************************************************************/
 /*!
     @brief  Control the DC Motor direction and action
-    @param  cmd The action to perform, can be FORWARD, BACKWARD or RELEASE
+    @param  cmd The action to perform, can be FORWARD, BACKWARD, RELEASE,
+	of BRAKE.  BRAKE is intended to implement the "short-brake" supported by
+	the motor driver chip and should only be used for short durations (<100ms) 
+	and	only after slowing the motor from full speed first.  It is not
+	intended to prevent the motor from free-spinning while not in motion but
+	to counteract the motor's inertia while in motion.
 */
 /**************************************************************************/
 void Adafruit_DCMotor::run(uint8_t cmd) {
@@ -237,6 +242,10 @@ void Adafruit_DCMotor::run(uint8_t cmd) {
   case RELEASE:
     MC->setPin(IN1pin, LOW);
     MC->setPin(IN2pin, LOW);
+    break;
+  case BRAKE:
+    MC->setPin(IN1pin, HIGH);
+    MC->setPin(IN2pin, HIGH);
     break;
   }
 }


### PR DESCRIPTION
Implemented brake mode to allow for electric braking of the motor.  Also added a note about how this is intended to implement the "short-brake" of the motor driver chip and not to prevent "free-wheeling".

I successfully used this code to stop a motor using the DCMotor/Stepper Featherwing by applying braking mode for 30 milliseconds and it greatly increased the stopping point of my motor.  

I added the function to the DCMotorTest example sketch to demonstrate it being used successfully:

```
/*
This is a test sketch for the Adafruit assembled Motor Shield for Arduino v2
It won't work with v1.x motor shields! Only for the v2's with built in PWM
control

For use with the Adafruit Motor Shield v2
---->	http://www.adafruit.com/products/1438
*/

#include <Adafruit_MotorShield.h>

// Create the motor shield object with the default I2C address
Adafruit_MotorShield AFMS = Adafruit_MotorShield();
// Or, create it with a different I2C address (say for stacking)
// Adafruit_MotorShield AFMS = Adafruit_MotorShield(0x61);

// Select which 'port' M1, M2, M3 or M4. In this case, M1
Adafruit_DCMotor *myMotor = AFMS.getMotor(1);
// You can also make another motor on port M2
//Adafruit_DCMotor *myOtherMotor = AFMS.getMotor(2);

void setup() {
  Serial.begin(9600);           // set up Serial library at 9600 bps
  Serial.println("Adafruit Motorshield v2 - DC Motor test!");

  if (!AFMS.begin()) {         // create with the default frequency 1.6KHz
  // if (!AFMS.begin(1000)) {  // OR with a different frequency, say 1KHz
    Serial.println("Could not find Motor Shield. Check wiring.");
    while (1);
  }
  Serial.println("Motor Shield found.");

  // Set the speed to start, from 0 (off) to 255 (max speed)
  myMotor->setSpeed(150);
  myMotor->run(FORWARD);
  // turn on motor
  myMotor->run(RELEASE);
}

void loop() {
  uint8_t i;

  Serial.print("tick");

  myMotor->run(FORWARD);
  for (i=0; i<255; i++) {
    myMotor->setSpeed(i);
    delay(10);
  }
  for (i=255; i>=50; i--) {
    myMotor->setSpeed(i);
    delay(10);
  }
  myMotor->run(BRAKE);
  delay(30);
  Serial.print("tock");

  myMotor->run(BACKWARD);
  for (i=0; i<255; i++) {
    myMotor->setSpeed(i);
    delay(10);
  }
  for (i=255; i>=50; i--) {
    myMotor->setSpeed(i);
    delay(10);
  }
  myMotor->run(BRAKE);
  delay(30);
  Serial.print("tech");
  myMotor->run(RELEASE);
  delay(1000);
}
```

As you can see from the driver's datasheet:
![image](https://user-images.githubusercontent.com/30270489/222879997-cfdae584-4970-412c-af49-3824256bc800.png)

pulling both in pins high actually drives both output pins low, regardless of what is set for the PWM pin.  So there is no risk of burning out the motor or the driver.